### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+final_drivers


### PR DESCRIPTION
removes common python files from the git repo. Stops `final_drivers` being uploaded