### PR TITLE
Add argument parser for setting training and racing parameters.

### DIFF
--- a/gaming_assembly.py
+++ b/gaming_assembly.py
@@ -5,17 +5,8 @@ import pygame
 import pyparticles
 import random, math, itertools, time, pickle
 
-# declare size of window and track to use
-(width, height) = (1200, 450)
-track = 'track.bmp'
 # given track, place checkpoints
 checkpoints = [(400,150),(500,70),(600,60),(640,140),(605,210),(680,300),(720,380),(580,390),(450,350),(320,320),(250,235),(110,325),(60,200),(125,75),(290,90)]
-
-# set up run parameters
-duration = 60
-n_generations = 40
-generation_size = 300
-n_to_keep = 10
 
 # for ease, define colours here
 RED = (255,0,0)
@@ -24,11 +15,8 @@ GREY = (230,230,230)
 BLUE = (0,0,255)
 BLACK = (0,0,0)
 
-# Train to create save file of best racers, Race to race them on a starting grid
-Train = True
-Race = True
 
-if Train:
+def do_training(duration, n_generations, generation_size, n_to_keep, track, driver_file='final_drivers'):
 	
 	# initiate display and display options
 	screen = pygame.display.set_mode((width, height))
@@ -190,15 +178,16 @@ if Train:
 			env.addParticles(1, x=checkpoints[0][0], y=checkpoints[0][1], speed=0, size=5)
 
 		# save these particles to file
-		with open('final_drivers','wb') as output:
+		with open(driver_file, 'wb') as output:
 			driver_list = sorted_list[:10]
 			pickle.dump(driver_list, output)
 
 		n += 1
 
-if Race:
+
+def do_race(duration, driver_file='final_drivers'):
 	# load in drivers
-	with open('final_drivers','rb') as input:
+	with open(driver_file, 'rb') as input:
 		driver_list = pickle.load(input)
 
 	# initiate race window
@@ -343,3 +332,24 @@ if Race:
 
 	# sort the cars, produce a final leaderboard
 	sorted_list = sorted(particle_list, key=lambda particle:particle.score)[::-1][:10]
+
+
+
+if __name__ == "__main__":
+	# set up run parameters
+	duration = 60
+	n_generations = 40
+	generation_size = 300
+	n_to_keep = 10
+	# declare size of window and track to use
+	(width, height) = (1200, 450)
+	track = 'track.bmp'
+
+	# Train to create save file of best racers, Race to race them on a starting grid
+	Train = True
+	Race = True
+
+	if Train:
+		do_training(duration, n_generations, generation_size, n_to_keep, track)
+	if Race:
+		do_race(track)

--- a/gaming_assembly.py
+++ b/gaming_assembly.py
@@ -4,6 +4,7 @@
 import pygame
 import pyparticles
 import random, math, itertools, time, pickle
+import argparse
 
 # given track, place checkpoints
 checkpoints = [(400,150),(500,70),(600,60),(640,140),(605,210),(680,300),(720,380),(580,390),(450,350),(320,320),(250,235),(110,325),(60,200),(125,75),(290,90)]
@@ -16,7 +17,7 @@ BLUE = (0,0,255)
 BLACK = (0,0,0)
 
 
-def do_training(duration, n_generations, generation_size, n_to_keep, track, driver_file='final_drivers'):
+def do_training(duration, n_generations, generation_size, n_to_keep, track, driver_file):
 	
 	# initiate display and display options
 	screen = pygame.display.set_mode((width, height))
@@ -185,7 +186,7 @@ def do_training(duration, n_generations, generation_size, n_to_keep, track, driv
 		n += 1
 
 
-def do_race(duration, driver_file='final_drivers'):
+def do_race(duration, track, driver_file):
 	# load in drivers
 	with open(driver_file, 'rb') as input:
 		driver_list = pickle.load(input)
@@ -336,20 +337,35 @@ def do_race(duration, driver_file='final_drivers'):
 
 
 if __name__ == "__main__":
-	# set up run parameters
-	duration = 60
-	n_generations = 40
-	generation_size = 300
-	n_to_keep = 10
+	# set up run parameters from command line options
+	parser = argparse.ArgumentParser(description='Robocar training and racing simulation.')
+	parser.add_argument('-t', '--train', dest='Train', 
+						action='store_true', default=False, help='Train the model.')
+	parser.add_argument('-r', '--race', dest='Race',
+                     	action='store_true', default=False, help='Race the trained model.')
+	parser.add_argument('-d', '--duration', dest='duration', 
+						type=int, default=60, help='Number of seconds per generation.')
+	parser.add_argument('-n', '--n_generations', dest='n_generations',
+	                    type=int, default=40, help='Number of generations.')
+	parser.add_argument('-s', '--generation_size', dest='generation_size',
+	                    type=int, default=300, help='Number of cars per generation.')
+	parser.add_argument('-k', '--n_to_keep', dest='n_to_keep',
+	                    type=int, default=10, help='Number from each generation to keep.')
+	parser.add_argument('--track', dest='track',
+	                    default='track.bmp', help='Track file to use for training or racing.')
+	parser.add_argument('--final_drivers', dest='final_drivers',
+                     	default='final_drivers', help='Drivers file to use for training and testing.')
+
+
+	args = parser.parse_args()
+
 	# declare size of window and track to use
 	(width, height) = (1200, 450)
-	track = 'track.bmp'
 
-	# Train to create save file of best racers, Race to race them on a starting grid
-	Train = True
-	Race = True
+	if not args.Train and not args.Race:
+		parser.print_help()
 
-	if Train:
-		do_training(duration, n_generations, generation_size, n_to_keep, track)
-	if Race:
-		do_race(track)
+	if args.Train:
+		do_training(args.duration, args.n_generations, args.generation_size, args.n_to_keep, args.track, args.final_drivers)
+	if args.Race:
+		do_race(args.duration, args.track, args.final_drivers)


### PR DESCRIPTION
Put the training and racing into functions which are now called from the added main function. The main function runs argparse, which will read through command line arguments to determine if the user wants to train or race as well other parameters. 

For example, to run a training with 100 cars for 100 generations and saving the outputs to a new file called "training_100cars_100generations."
```bash
python gaming_assembly.py -t -s 100 -n 100 --final_drivers training_100cars_100generations
```

Argparse also gives a very nice help output:
```
usage: gaming_assembly.py [-h] [-t] [-r] [-d DURATION] [-n N_GENERATIONS]
                          [-s GENERATION_SIZE] [-k N_TO_KEEP] [--track TRACK]
                          [--final_drivers FINAL_DRIVERS]

Robocar training and racing simulation.

optional arguments:
  -h, --help            show this help message and exit
  -t, --train           Train the model.
  -r, --race            Race the trained model.
  -d DURATION, --duration DURATION
                        Number of seconds per generation.
  -n N_GENERATIONS, --n_generations N_GENERATIONS
                        Number of generations.
  -s GENERATION_SIZE, --generation_size GENERATION_SIZE
                        Number of cars per generation.
  -k N_TO_KEEP, --n_to_keep N_TO_KEEP
                        Number from each generation to keep.
  --track TRACK         Track file to use for training or racing.
  --final_drivers FINAL_DRIVERS
                        Drivers file to use for training and testing.
```
